### PR TITLE
Build applications in external projects and include them here

### DIFF
--- a/parts/machine-learning/build.sh
+++ b/parts/machine-learning/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 VERSION="$1"
-PYTHON_PART_INSTALL_BIN="${PWD}/../../python/install/usr/local/bin"
+PYTHON_PART_INSTALL_BIN="${PWD}/../../dependencies/install/usr/local/bin"
 
 mkdir -p /opt/venv/
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -165,28 +165,6 @@ apps:
       - network-bind
 
 parts:
-  python:
-    source: https://www.python.org/ftp/python/3.11.4/Python-3.11.4.tgz
-    plugin: make
-    override-build: |
-      ./configure --enable-optimizations --with-ensurepip=install
-      snapcraftctl build
-    build-packages:
-      - libssl-dev
-      - zlib1g-dev
-      - libbz2-dev
-      - libreadline-dev
-      - libsqlite3-dev
-      - xz-utils
-      - libffi-dev
-      - libncurses5-dev
-      - libgdbm-dev
-      - libnss3-dev
-    stage-packages:
-      - libtcl8.6
-      - libtk8.6
-      - libxft2
-
   ffmpeg:
     plugin: dump
     # These builds are linked from the official ffmpeg site, so I assume they are safe.
@@ -301,7 +279,7 @@ parts:
     stage-packages:
       - libgomp1
     after:
-      - python
+      - dependencies
 
   cli:
     plugin: npm
@@ -328,6 +306,7 @@ parts:
       - immich-distribution-lego/latest/stable
       - immich-distribution-libvips/latest/stable
       - immich-distribution-node/latest/stable
+      - immich-distribution-python/latest/stable
 
   scripts:
     source: src
@@ -344,7 +323,7 @@ parts:
     override-build:
       ../../python/install/usr/local/bin/python3 ../../python/install/usr/local/bin/pip3 install watchfiles requests psycopg2-binary --target $SNAPCRAFT_PART_INSTALL/opt/pipsyncenv
     after:
-      - python
+      - dependencies
 
   patches:
     source: patches

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,10 @@ layout:
     symlink: $SNAP_COMMON/reverse-geocoding-dump
   $SNAP/usr/src/app/upload:
     symlink: $SNAP_COMMON/upload
+  /usr/etc/ImageMagick-7:
+    symlink: $SNAP/usr/etc/ImageMagick-7
+  /usr/lib/ImageMagick-7.1.1:
+    symlink: $SNAP/usr/lib/ImageMagick-7.1.1
 
 apps:
   psql:
@@ -203,193 +207,6 @@ parts:
       cp $SNAPCRAFT_PART_SRC/ffmpeg $SNAPCRAFT_PART_INSTALL/bin
       cp $SNAPCRAFT_PART_SRC/ffprobe $SNAPCRAFT_PART_INSTALL/bin
 
-  libraw:
-    plugin: autotools
-    source: https://github.com/libraw/libraw/archive/0.21.1.tar.gz
-    source-checksum: "sha256/b63d7ffa43463f74afcc02f9083048c231349b41cc9255dec0840cf8a67b52e0"
-    override-build: |
-      autoreconf --install
-      snapcraftctl build
-    build-packages:
-      - zlib1g-dev
-      - libjpeg8-dev
-    stage-packages:
-      - libgomp1
-      - libjpeg-turbo8
-      - liblcms2-2
-
-  cgif:
-    plugin: meson
-    meson-version: "1.2.1"
-    source: https://github.com/dloebl/cgif.git
-    source-tag: "V0.3.2"
-
-  imagemagick:
-    plugin: make
-    source: https://github.com/ImageMagick/ImageMagick/archive/7.1.1-13.tar.gz
-    source-checksum: "sha256/8e3ce1aaad19da9f2ca444072bcc631d193a219e3ee11c13ad6d3c895044142c"
-    override-build: |
-      ./configure --with-modules
-      snapcraftctl build
-    build-packages:
-      - libltdl-dev
-    after:
-      - cgif
-    stage-packages:
-      - libcairo2
-      - libdatrie1
-      - libde265-0
-      - libdjvulibre21
-      - libfontconfig1
-      - libfreetype6
-      - libfribidi0
-      - libgomp1
-      - libgraphite2-3
-      - libharfbuzz0b
-      - libheif1
-      - libicu66
-      - libilmbase24
-      - libjbig0
-      - libjpeg-turbo8
-      - liblcms2-2
-      - liblqr-1-0
-      - libltdl7
-      - libnuma1
-      - libopenexr24
-      - libopenjp2-7
-      - libpango-1.0-0
-      - libpangocairo-1.0-0
-      - libpangoft2-1.0-0
-      - libpixman-1-0
-      - libpng16-16
-      - libthai0
-      - libtiff5
-      - libwebp6
-      - libwebpdemux2
-      - libwebpmux3
-      - libwmf0.2-7
-      - libx11-6
-      - libx265-179
-      - libxau6
-      - libxcb-render0
-      - libxcb-shm0
-      - libxcb1
-      - libxdmcp6
-      - libxext6
-      - libxml2
-      - libxrender1
-
-  libvips:
-    plugin: meson
-    meson-version: "1.2.1"
-    source: https://github.com/libvips/libvips/releases/download/v8.14.3/vips-8.14.3.tar.xz
-    source-checksum: "sha256/f884d61a6b54c99cdae855001c8b9523e13b4982be7e76cac03faccb91be105c"
-    build-packages:
-      # From https://github.com/libvips/libvips/wiki/Build-for-Ubuntu
-      - libfftw3-dev
-      - libopenexr-dev
-      - libgsf-1-dev
-      - libglib2.0-dev
-      - liborc-dev
-      - libopenslide-dev
-      - libmatio-dev
-      - libwebp-dev
-      - libjpeg-turbo8-dev
-      - libexpat1-dev
-      - libexif-dev
-      - libtiff5-dev
-      - libcfitsio-dev
-      - libpoppler-glib-dev
-      - librsvg2-dev
-      - libpango1.0-dev
-      - libopenjp2-7-dev
-      - libimagequant-dev
-      # From errors complaining about missing packages during build
-      - libgirepository1.0-dev
-      # Packages enabling more features in libvips
-      - libheif-dev
-      - libtiff-dev
-    stage-packages:
-      - libaec0
-      - libasn1-8-heimdal
-      - libbrotli1
-      - libcairo-gobject2
-      - libcairo2
-      - libcfitsio8
-      - libcurl3-gnutls
-      - libdatrie1
-      - libde265-0
-      - libexif12
-      - libfftw3-double3
-      - libfontconfig1
-      - libfreetype6
-      - libfribidi0
-      - libgdk-pixbuf2.0-0
-      - libgif7
-      - libgomp1
-      - libgraphite2-3
-      - libgsf-1-114
-      - libgssapi3-heimdal
-      - libharfbuzz0b
-      - libhcrypto4-heimdal
-      - libhdf5-103
-      - libheif1
-      - libheimbase1-heimdal
-      - libheimntlm0-heimdal
-      - libhx509-5-heimdal
-      - libicu66
-      - libilmbase24
-      - libimagequant0
-      - libjbig0
-      - libjpeg-turbo8
-      - libkrb5-26-heimdal
-      - liblcms2-2
-      - libldap-2.4-2
-      - liblqr-1-0
-      - libltdl7
-      - libmagickcore-6.q16-6
-      - libmatio9
-      - libnghttp2-14
-      - libnspr4
-      - libnss3
-      - libnuma1
-      - libopenexr24
-      - libopenjp2-7
-      - libopenslide0
-      - liborc-0.4-0
-      - libpango-1.0-0
-      - libpangocairo-1.0-0
-      - libpangoft2-1.0-0
-      - libpixman-1-0
-      - libpng16-16
-      - libpoppler-glib8
-      - libpoppler97
-      - libpsl5
-      - libroken18-heimdal
-      - librsvg2-2
-      - librtmp1
-      - libsasl2-2
-      - libssh-4
-      - libsz2
-      - libthai0
-      - libtiff5
-      - libwebp6
-      - libwebpdemux2
-      - libwebpmux3
-      - libwind0-heimdal
-      - libx11-6
-      - libx265-179
-      - libxau6
-      - libxcb-render0
-      - libxcb-shm0
-      - libxcb1
-      - libxdmcp6
-      - libxext6
-      - libxml2
-      - libxrender1
-    after:
-      - cgif
-
   # "npm run build" builds: server, microservices, cli
   server:
     plugin: npm
@@ -511,37 +328,15 @@ parts:
     after:
       - node
 
-  redis:
-    source: https://github.com/redis/redis.git
-    source-tag: 7.0.9
-    plugin: make
-    build-packages:
-      - pkg-config
-    override-build: |
-      make
-      make PREFIX=$SNAPCRAFT_PART_INSTALL install
-    prime:
-      - bin/redis-server
-
-  postgres:
+  dependencies:
     plugin: nil
     stage-snaps:
+      - immich-distribution-redis/latest/stable
       - immich-distribution-postgres/latest/stable
-
-  typesense:
-    plugin: nil
-    stage-snaps:
       - immich-distribution-typesense/latest/stable
-
-  haproxy:
-    plugin: nil
-    stage-snaps:
       - immich-distribution-haproxy/latest/stable
-
-  lego:
-    plugin: nil
-    stage-snaps:
       - immich-distribution-lego/latest/stable
+      - immich-distribution-libvips/latest/stable
 
   scripts:
     source: src

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -321,7 +321,7 @@ parts:
   sync:
     plugin: nil
     override-build:
-      ../../python/install/usr/local/bin/python3 ../../python/install/usr/local/bin/pip3 install watchfiles requests psycopg2-binary --target $SNAPCRAFT_PART_INSTALL/opt/pipsyncenv
+      ../../dependencies/install/usr/local/bin/python3 ../../dependencies/install/usr/local/bin/pip3 install watchfiles requests psycopg2-binary --target $SNAPCRAFT_PART_INSTALL/opt/pipsyncenv
     after:
       - dependencies
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -165,14 +165,6 @@ apps:
       - network-bind
 
 parts:
-  node:
-    plugin: nil
-    override-build: |
-      if [ ! -f "$SNAPCRAFT_PART_INSTALL/bin/node" ]; then
-        curl -s https://nodejs.org/dist/v18.16.0/node-v18.16.0-linux-x64.tar.xz \
-        | tar xJf - -C "$SNAPCRAFT_PART_INSTALL" --no-same-owner --strip-components=1
-      fi
-
   python:
     source: https://www.python.org/ftp/python/3.11.4/Python-3.11.4.tgz
     plugin: make
@@ -279,9 +271,7 @@ parts:
       - libxcb-shm0
       - libxml2
     after:
-      - node
-      - libvips
-      - imagemagick
+      - dependencies
 
   web:
     plugin: npm
@@ -300,7 +290,7 @@ parts:
       cp -r build $SNAPCRAFT_PART_INSTALL/usr/src/web
       cp package.json package-lock.json $SNAPCRAFT_PART_INSTALL/usr/src/web
     after:
-      - node
+      - dependencies
       - patches
 
   machine-learning:
@@ -326,7 +316,7 @@ parts:
       cp -r bin $SNAPCRAFT_PART_INSTALL/usr/src/cli
       cp package.json package-lock.json $SNAPCRAFT_PART_INSTALL/usr/src/cli
     after:
-      - node
+      - dependencies
 
   dependencies:
     plugin: nil
@@ -337,6 +327,7 @@ parts:
       - immich-distribution-haproxy/latest/stable
       - immich-distribution-lego/latest/stable
       - immich-distribution-libvips/latest/stable
+      - immich-distribution-node/latest/stable
 
   scripts:
     source: src

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -524,55 +524,24 @@ parts:
       - bin/redis-server
 
   postgres:
-    source: https://ftp.postgresql.org/pub/source/v15.2/postgresql-15.2.tar.bz2
-    plugin: make
-    build-packages:
-      - libreadline-dev
-      - zlib1g-dev
-      - uuid-dev
-    override-build: |
-      ./configure --enable-thread-safety --with-uuid=e2fs --with-gnu-ld
-      snapcraftctl build
-      cd contrib
-      make
-      make install DESTDIR=$SNAPCRAFT_PART_INSTALL
+    plugin: nil
+    stage-snaps:
+      - immich-distribution-postgres/latest/stable
 
   typesense:
-    source: https://dl.typesense.org/releases/0.24.1/typesense-server-0.24.1-linux-amd64.tar.gz
-    plugin: dump
-    organize:
-      typesense-server: bin/typesense-server
+    plugin: nil
+    stage-snaps:
+      - immich-distribution-typesense/latest/stable
 
   haproxy:
-    source: http://git.haproxy.org/git/haproxy-2.6.git
-    source-tag: v2.6.10
-    plugin: make
-    make-parameters:
-      - TARGET=linux-glibc
-      - USE_OPENSSL=1
-      - USE_ZLIB=1
-      - USE_PCRE=1
-    build-packages:
-      - build-essential
-      - libssl-dev
-      - libpcre3-dev
-      - libz-dev
-    stage:
-      - -usr/local/doc
-      - -usr/local/share
-    organize:
-      usr/local/sbin/haproxy: bin/haproxy
+    plugin: nil
+    stage-snaps:
+      - immich-distribution-haproxy/latest/stable
 
   lego:
-    source: https://github.com/go-acme/lego.git
-    source-tag: v4.10.2
-    plugin: go
-    build-environment:
-      - GO111MODULE: "on"
-    override-build: |
-      make build
-      mkdir -p $SNAPCRAFT_PART_INSTALL/bin
-      cp dist/lego $SNAPCRAFT_PART_INSTALL/bin
+    plugin: nil
+    stage-snaps:
+      - immich-distribution-lego/latest/stable
 
   scripts:
     source: src


### PR DESCRIPTION
I waste a lot of time building the same version of these software over and over again. I have moved them to an external snap that I include here. That should result in the same result, but should be considerable faster.