### PR TITLE
Sync feature: Limit sync file delete

### DIFF
--- a/src/bin/sync-service.py
+++ b/src/bin/sync-service.py
@@ -177,11 +177,12 @@ def file_watcher(event: threading.Event, db: ImmichDatabase, api: ImmichAPI, api
                 import_asset(db, api, api_key, user_path, c_path)
             elif c_type == Change.deleted:
                 file_age_days = (time.time() - os.path.getmtime(os.path.relpath(c_path, user_path))) / 86400
-                if file_age_days < 365:
-                    log(f"{c_path} deleted, asset is {file_age_days} days old, delete asset from Immich")
+                file_age_delete_limit = int(os.environ.get("SYNC_FILE_AGE_DELETE_LIMIT", 365))
+                if file_age_days < file_age_delete_limit:
+                    log(f"{c_path} deleted, asset is {file_age_days} days old (limit {file_age_delete_limit} days), delete asset from Immich")
                     delete_asset(db, api, c_path, user_path)
                 else:
-                    log(f"{c_path} deleted, asset is 365 days or older ({file_age_days} days), do NOT delete from Immich")
+                    log(f"{c_path} deleted, asset is {file_age_delete_limit} days or older ({file_age_days} days), do NOT delete from Immich")
 
 def database_watcher(event: threading.Event, db: ImmichDatabase, api: ImmichAPI, user_path: str) -> None:
     log("Database watcher thread running...")

--- a/src/bin/sync-service.py
+++ b/src/bin/sync-service.py
@@ -176,8 +176,12 @@ def file_watcher(event: threading.Event, db: ImmichDatabase, api: ImmichAPI, api
                 log(f"{c_path} modified, re-import asset to Immich")
                 import_asset(db, api, api_key, user_path, c_path)
             elif c_type == Change.deleted:
-                log(f"{c_path} deleted, mark asset as removed")
-                delete_asset(db, api, c_path, user_path)
+                file_age_days = (time.time() - os.path.getmtime(os.path.relpath(c_path, user_path))) / 86400
+                if file_age_days < 365:
+                    log(f"{c_path} deleted, asset is {file_age_days} days old, delete asset from Immich")
+                    delete_asset(db, api, c_path, user_path)
+                else:
+                    log(f"{c_path} deleted, asset is 365 days or older ({file_age_days} days), do NOT delete from Immich")
 
 def database_watcher(event: threading.Event, db: ImmichDatabase, api: ImmichAPI, user_path: str) -> None:
     log("Database watcher thread running...")

--- a/src/bin/sync-service.sh
+++ b/src/bin/sync-service.sh
@@ -21,9 +21,16 @@ done
 
 cat $SNAP/etc/modify-db.sql | $SNAP/bin/psql -d immich
 
+SYNC_FILE_AGE_DELETE_LIMIT="$(snapctl get sync-file-age-delete-limit)"
+if [ -z "$SYNC_FILE_AGE_DELETE_LIMIT" ]; then
+    # Default to 100 years, this more or less disables the feature
+    # This user need to explicitly set this to a lower value to enable it
+    SYNC_FILE_AGE_DELETE_LIMIT=36500
+fi
+
 for KEY in $(snapctl get sync); do
     {
-        IMMICH_API_KEY="$KEY" $SNAP/usr/local/bin/python3 $SNAP/bin/sync-service.py
+        IMMICH_API_KEY="$KEY" SYNC_FILE_AGE_DELETE_LIMIT="$SYNC_FILE_AGE_DELETE_LIMIT" $SNAP/usr/local/bin/python3 $SNAP/bin/sync-service.py
     } &
 done
 


### PR DESCRIPTION
This PR adds a configurable upper limit on file deletions in the sync folder. I added this to allow me to delete old files from the phone, and to prevent these deletions from remove files from the Immich as well.

I intend to use this like this:
* Set `snap set immich-distribution sync-file-age-delete-limit=365` to ignore files older or equal to a year
* Setup a cronjob in the sync-folder that removes files older than 400 days.

This should:
* Clean up old assets on my phone (and sync folder), assets that are already imported to Immich
* The delete event will be ignored because 400 > 365

This setting is opt-in, you need to set `sync-file-age-delete-limit` to enable it, it will default to 100 years effectively disabling this feature. For really old files (like digitalized albums with metadata set over 100 years ago) or files with broken/incorrect metadata may still trigger this feature.

Note:
This will check against the modification time on the file in the filesystem in the sync folder, not the EXIF metadata.