### PR TITLE
Make http and https ports configurable

### DIFF
--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -19,45 +19,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  prepare:
-    runs-on: ubuntu-latest
-
-    outputs:
-      runjob: ${{ steps.detect.outputs.runjob }}
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Detect if this commit already have an active workflow running
-        id: detect
-        env:
-          GH_TOKEN: ${{ github.token }}      
-        run: |
-          sleep $(( RANDOM % 10 ))
-          if gh run list --status in_progress --json headSha --jq ".[].headSha" | grep -q "$GITHUB_SHA"; then
-            echo "This commit already have an active workflow running, canceling this one."
-            echo "runjob=yes" >> $GITHUB_OUTPUT
-          fi
-
   build:
-    name: Build Snap Package
+    name: Build and Test Snap Package
     runs-on: ubuntu-latest
-    needs: [ prepare ]
-    if: ${{ needs.prepare.outputs.runjob == 'yes' }}
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: snapcore/action-build@v1
-      - uses: actions/cache/save@v3
-        with:
-          path: "*.snap"
-          key: ${{ github.workflow }}-${{ github.sha }}
-
-  test:
-    name: Install and Test Snap Package
-    runs-on: ubuntu-latest
-    needs: [ prepare, build ]
-    if: ${{ needs.prepare.outputs.runjob == 'yes' }}
 
     services:
       selenium:
@@ -67,19 +31,20 @@ jobs:
           - 4444:4444
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache/restore@v3
-        with:
-          path: "*.snap"
-          key: ${{ github.workflow }}-${{ github.sha }}
-        
-      - name: Install package
-        run: sudo snap install --dangerous *.snap
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-      - name: Install requirements
+      - name: Build snap package
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: TEST | Install package
+        run: sudo snap install --dangerous ${{ steps.build.outputs.snap }}
+
+      - name: TEST | Install requirements
         run: pip install -r tests/requirements.txt
 
-      - name: Run Selenium Tests
+      - name: TEST | Run Selenium Tests
         run: make ci -C tests
 
       - name: Upload test report

--- a/docs/docs/configuration/haproxy.md
+++ b/docs/docs/configuration/haproxy.md
@@ -10,6 +10,18 @@ sudo snap set immich-distribution https-enabled="true"
 
 The above command will enable the TLS frontend, this will be enabled if you configure [https](/configuration/https) with Let's encrypt.
 
+## Change port numbers
+
+HAProxy listens on `*:80` (all interfaces, tcp port 80) by default, and `*:443` if https is enabled. If you like to change these ports update the following configuration keys.
+
+```bash title="Use port 8880 for HTTP traffic"
+sudo snap set immich-distribution haproxy-http-bind="*:8880"
+```
+
+```bash title="Use port 4443 for HTTPS traffic"
+sudo snap set immich-distribution haproxy-https-bind="*:4443"
+```
+
 ## Loading screen
 
 The loading screen below uses haproxy stats to display it's information. The loading screen is displayed if the Immich Web frontend is down.

--- a/docs/docs/install.md
+++ b/docs/docs/install.md
@@ -39,18 +39,18 @@ A computer with a relatively modern Intel or AMD based CPU, for example the AVX 
 
 ### Used ports
 
-Immich Distribution requires ports `80`, `443`, `3000-3003`, `5432`, `6379`, `8108` to be unused, only port 80 (and possible 443) needs to be available over the network. Immich will fail to start if they are used by another application.
+Immich Distribution requires ports `3000-3003`, `5432`, `6379` and `8108` to be unused, port `80` is also required by default, and port `443` if you enable https. See [HAProxy](configuration/haproxy.md) if you like to change the http or https ports. Immich will fail to start if these ports are used by another application.
 
 ??? Info "Used ports with service names"
 
-    | Port | Interface | Comment |
-    | ---- | --------- | ------- |
-    | `80`   | all | HAProxy - Reverse proxy |
-    | `443`  | all | HAProxy (only if HTTPS is enabled) |
-    | `3000-3003` | all | Immich Services |
-    | `5432` | lo | Postgres - Relation database |
-    | `6379` | lo | Redis - In-memory KV database |
-    | `8108` | lo | Typesense - Search database |
+    | Port | Interface | Configurable | Comment |
+    | ---- | --------- | ------------ | ------- |
+    | `80`   | all | YES | HAProxy - Reverse proxy |
+    | `443`  | all | YES | HAProxy (only if HTTPS is enabled) |
+    | `3000-3003` | all | NO | Immich Services |
+    | `5432` | lo | NO | Postgres - Relation database |
+    | `6379` | lo | NO | Redis - In-memory KV database |
+    | `8108` | lo | NO | Typesense - Search database |
 
 ## Connecting to the server
 

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -15,6 +15,14 @@ if [[ $(snapctl get typesense-key) == "" ]]; then
     snapctl set typesense-key="$(random_string)"
 fi
 
+if [[ $(snapctl get haproxy-http-bind) == "" ]]; then
+    snapctl set haproxy-http-bind="*:80"
+fi
+
+if [[ $(snapctl get haproxy-https-bind) == "" ]]; then
+    snapctl set haproxy-https-bind="*:443"
+fi
+
 # Restart services
 snapctl restart immich-distribution.postgres
 snapctl restart immich-distribution.typesense

--- a/src/bin/load-env
+++ b/src/bin/load-env
@@ -56,6 +56,9 @@ else
     export HAPROXY_HTTPS_FRONTEND_DATA="disabled"
 fi
 
+export HAPROXY_HTTP_BIND="$(snapctl get haproxy-http-bind)"
+export HAPROXY_HTTPS_BIND="$(snapctl get haproxy-https-bind)"
+
 drop_privileges() {
     $SNAP/usr/bin/setpriv \
         --clear-groups \

--- a/src/etc/haproxy.cfg
+++ b/src/etc/haproxy.cfg
@@ -7,7 +7,7 @@ defaults
   errorfile 503 "${SNAP}/etc/5xx.http"
 
 frontend http
-    bind *:80
+    bind ${HAPROXY_HTTP_BIND}
 
     use_backend acme if { path_beg /.well-known/acme-challenge/ }
     use_backend be_server if { path_beg /api }
@@ -16,7 +16,7 @@ frontend http
 
 frontend https
     "${HAPROXY_HTTPS_FRONTEND_DATA}"
-    bind *:443 ssl strict-sni crt "${ACME_CONFIG_PATH}/haproxy/" alpn h2,http/1.1
+    bind ${HAPROXY_HTTP_BIND} ssl strict-sni crt "${ACME_CONFIG_PATH}/haproxy/" alpn h2,http/1.1
 
     use_backend acme if { path_beg /.well-known/acme-challenge/ }
     use_backend be_server if { path_beg /api }


### PR DESCRIPTION
This PR makes http and https frontends in HAProxy configurable. They default to `*:80` and `*:443` like before. The new configuration keys are:

`haproxy-http-bind` and `haproxy-https-bind`

This allows the user to:

* Change the listening port
* Change what interface the service listens to

ref #117 