### PR TITLE
Add config for ml-device

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -20,6 +20,10 @@ snapctl unset typesense-key
 mkdir -p $SNAP_COMMON/{pgsql,redis,reverse-geocoding-dump,upload,sync,backups,acme,cache}
 chown snap_daemon:snap_daemon $SNAP_COMMON/pgsql
 
+if [[ $(snapctl get ml-device) == "" ]]; then
+    snapctl set ml-device="cpu"
+fi
+
 if [[ $(snapctl get database-password) == "" ]]; then
     snapctl set database-password="$(random_string)"
 fi

--- a/src/bin/load-env
+++ b/src/bin/load-env
@@ -24,6 +24,8 @@ export LC_CTYPE="C"
 # I think NODE_ENV is not used by Immich anymore, keep it for now
 export NODE_ENV="production"
 
+export DEVICE="$(snapctl get ml-device)"
+
 export DB_HOSTNAME="127.0.0.1"
 export DB_USERNAME="postgres"
 export DB_PASSWORD="$(snapctl get database-password)"


### PR DESCRIPTION
This should allow the snap distribution to enable the user to choose which device to use for machine learning.

Please let me know if I missed anything.