### PR TITLE
Fix search_path for vector operations

### DIFF
--- a/src/bin/postgres-configure
+++ b/src/bin/postgres-configure
@@ -2,6 +2,6 @@
 
 . $SNAP/bin/load-env
 
-# Enable vectors.so extension in postgresql.conf
-# NOTE: This the #, this will only match once per installation
-sed -i "s/^#shared_preload_libraries.*/shared_preload_libraries = 'vectors.so' # Added pgvecto-rs/" $PGDATA/postgresql.conf
+# NOTE: This the leading #, this will only match once per installation
+sed -i "s/^#shared_preload_libraries.*/shared_preload_libraries = 'vectors.so' # enable pgvector extension for immich vector search/" $PGDATA/postgresql.conf
+sed -i "s/^#search_path.*/search_path = '\"\$\$user\", public, vectors' # include vectors schema in search_path for immich queries/" $PGDATA/postgresql.conf


### PR DESCRIPTION
I _think_ upstream has removed an alter table from the database migrations that configured this. Upstream starts the database with -c flags, I will replicate that in postgresql.conf

This fixes #283 