### PR TITLE
Add automatic API key creation to manager service

### DIFF
--- a/parts/manager/bin/manager
+++ b/parts/manager/bin/manager
@@ -1,39 +1,16 @@
 #!/bin/bash
 set -eu -o pipefail
 
-# The manager is a small service that run different maintenance tasks in the
-# background that can't be run from the hooks during installation/upgrade.
+# The manager runs maintenance tasks in the background that can't be run 
+# from the hooks during installation/upgrade.
 
-MANAGER_MIGRATIONS_VERSION_TARGET="1"
-
-validate_version() {
-    if [[ ! $1 =~ ^[0-9]+$ ]]; then
-        echo "Invalid manager-migrations-version: $1"
-        exit 1
+# Check API key twice a day (at 06 and 18), the minute depends on the timer.
+# I regularly check this in case the user deletes the API key. This key will
+# be critical for the operation of the snap.
+CURRENT_HOUR=$(date +%H)
+if [[ "$CURRENT_HOUR" == "06" || "$CURRENT_HOUR" == "18" ]]; then
+    API_KEY_OUTPUT=$($SNAP/bin/immich-admin create-admin-api-key --name "immich-distribution" --check 2>/dev/null || true)
+    if [[ ${#API_KEY_OUTPUT} -gt 30 ]]; then
+        snapctl set admin-api-key="$API_KEY_OUTPUT"
     fi
-}
-
-# Load migrations
-for file in $SNAP/usr/lib/migrations/*; do
-    . "$file"
-done
-
-while sleep 5; do
-    MANAGER_MIGRATIONS_VERSION="$(snapctl get manager-migrations-version)"
-    validate_version "$MANAGER_MIGRATIONS_VERSION"
-
-    if [[ $MANAGER_MIGRATIONS_VERSION -lt $MANAGER_MIGRATIONS_VERSION_TARGET ]]; then
-        echo "Running manager migrations from version $MANAGER_MIGRATIONS_VERSION to $MANAGER_MIGRATIONS_VERSION_TARGET"
-        while [[ $MANAGER_MIGRATIONS_VERSION -lt $MANAGER_MIGRATIONS_VERSION_TARGET ]]; do
-            MANAGER_MIGRATIONS_VERSION=$((MANAGER_MIGRATIONS_VERSION + 1))
-            "manager_migration_$MANAGER_MIGRATIONS_VERSION"
-            if [[ $? -ne 0 ]]; then
-                echo "Failed to run manager migration $MANAGER_MIGRATIONS_VERSION"
-                exit 1
-            fi
-            snapctl set manager-migrations-version="$MANAGER_MIGRATIONS_VERSION"
-        done
-    else
-        sleep 60
-    fi
-done
+fi

--- a/parts/manager/usr/lib/migrations/001-restart-postgres
+++ b/parts/manager/usr/lib/migrations/001-restart-postgres
@@ -1,8 +1,0 @@
-
-manager_migration_1() {
-    if [ -e "$SNAP/usr/local/pgsql/share/extension/vectors--0.2.0.sql" ]; then
-        echo "Wait five minutes and then restart postgres. Immich has upgraded vecto.rs and we follow upstreams advice to restart postgres once after this upgrade."
-        sleep 300
-        snapctl restart immich-distribution.postgres
-    fi
-}

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -36,10 +36,6 @@ if [[ $(snapctl get acme-port) == "" ]]; then
     snapctl set acme-port="$(free_port)"
 fi
 
-if [[ $(snapctl get manager-migrations-version) == "" ]]; then
-    snapctl set manager-migrations-version="0"
-fi
-
 if [[ $(snapctl get sync-delete-threshold) == "" ]]; then
     snapctl set sync-delete-threshold="300"
 fi
@@ -54,6 +50,7 @@ snapctl unset metrics-api-enabled
 snapctl unset metrics-host-enabled
 snapctl unset metrics-io-enabled
 snapctl unset metrics-job-enabled
+snapctl unset manager-migrations-version
 
 if [[ $(snapctl get backup-database-daily) == "" ]]; then
     snapctl set backup-database-daily="false"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -120,6 +120,7 @@ apps:
     command: bin/manager
     daemon: simple
     restart-delay: 60s
+    timer: "00:00-24:00/24"
     after:
       - immich-server
 


### PR DESCRIPTION
- Create "immich-distribution" API key twice daily (6 AM/6 PM)
- Store generated key in snap configuration as admin-api-key
- Convert manager to timer-based execution for efficiency
- Remove migration system infrastructure (can be restored if needed)
- Clean up legacy manager-migrations-version configuration