### PR TITLE
Fix FileNotFoundError in sync service

### DIFF
--- a/parts/sync/sync_service/main.py
+++ b/parts/sync/sync_service/main.py
@@ -270,12 +270,13 @@ def import_watcher(event: threading.Event, db: ImmichDatabase, api: ImmichAPI, u
                 file_path = os.path.join(root, file)
                 relative_path = os.path.relpath(file_path, user_path)
                 user_id = api.get_user_id()
-                checksum = hash_file(file_path)
 
                 # Ignore missing files. This can happen if the file was deleted during execution.
                 if not os.path.exists(file_path):
                     log(f"File {file_path} has disappeared, skipping")
                     continue
+
+                checksum = hash_file(file_path)
 
                 #
                 # Update hash lookup table


### PR DESCRIPTION
Do not try to hash missing files