### PR TITLE
Fix postgres-configure sed not matching lines with leading whitespace

### DIFF
--- a/src/bin/postgres-configure
+++ b/src/bin/postgres-configure
@@ -3,7 +3,7 @@
 . $SNAP/bin/load-env
 
 # Always update shared_preload_libraries
-sed -i "s/^#\?shared_preload_libraries.*/shared_preload_libraries = 'vchord.so'/" $PGDATA/postgresql.conf
+sed -i "s/^[[:space:]]*#\?[[:space:]]*shared_preload_libraries.*/shared_preload_libraries = 'vchord.so'/" $PGDATA/postgresql.conf
 
 # Always update search_path
-sed -i "s/^#\?search_path.*/search_path = '\"\$\$user\", public'/" $PGDATA/postgresql.conf
+sed -i "s/^[[:space:]]*#\?[[:space:]]*search_path.*/search_path = '\"\$\$user\", public'/" $PGDATA/postgresql.conf


### PR DESCRIPTION
The sed patterns used ^#\? which required the line to start at column 0. On some installations, postgresql.conf has leading whitespace before shared_preload_libraries, causing the sed to silently skip the replacement. This left the old 'vectors' entry in place, preventing PostgreSQL from starting after the pgvecto.rs removal in era 2.