### PR TITLE
add RAF asset processing test

### DIFF
--- a/.github/actions/fetch-test-assets/action.yaml
+++ b/.github/actions/fetch-test-assets/action.yaml
@@ -5,7 +5,7 @@ inputs:
   revision:
     description: Commit of immich-app/test-assets to check out.
     required: false
-    default: 61131e84ec91d316265aebe375b3155308baaa89
+    default: c2d5f290a2e671fa2106fa8b7146991be27c0515
 
 runs:
   using: composite

--- a/tests/helpers/assets.py
+++ b/tests/helpers/assets.py
@@ -39,6 +39,7 @@ ALL_TEST_ASSETS = [
     UPSTREAM_TEST_ASSET_DIR / "formats/webp/denali.webp",
     UPSTREAM_TEST_ASSET_DIR / "formats/raw/Nikon/D80/glarus.nef",
     UPSTREAM_TEST_ASSET_DIR / "formats/raw/Nikon/D700/philadelphia.nef",
+    UPSTREAM_TEST_ASSET_DIR / "formats/raw/Fujifilm/X100V_compressed.RAF",
 ]
 
 EXIF_TEST_ASSETS = [


### PR DESCRIPTION
It was discovered in #385 that RAF files where broken, the issue was an regression in ImageMagick (the way I packaged it). Tests has been improved (already merged as part of #387) to detect this better in the future.