### PR TITLE
filter out prereleases from upstream release list

### DIFF
--- a/workflows/tools.sh
+++ b/workflows/tools.sh
@@ -95,7 +95,7 @@ get_latest_releases() {
     local result
     
     for i in $(seq 1 $retries); do
-        result=$(curl -s https://api.github.com/repos/immich-app/immich/releases | jq -r '.[].tag_name')
+        result=$(curl -s https://api.github.com/repos/immich-app/immich/releases | jq -r '.[] | select(.prerelease == false) | .tag_name')
         
         if [ -n "$result" ] && [ "$result" != "null" ]; then
             echo "$result"


### PR DESCRIPTION
Upstream published release candidates (v3.0.0-rc.*) for the first time. get_latest_releases returned all tags, and sort -V orders v3.0.0-rc.3 after v3.0.0, so the version bump script picked the RC. Filter on the GitHub API prerelease flag so only real releases are considered.