### PR TITLE
ci: pin snapcraft to 8.x for docs metrics fetch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,7 +30,12 @@ jobs:
 
       - name: Install snapcraft
         run: |
-          sudo snap install snapcraft --classic
+          # Pinned to 8.x: snapcraft 9.x crashes on "snapcraft metrics" when the
+          # store returns null data points (MetricsResponse pydantic validation
+          # error). Unpin once snapcraft allows null in Series.values, or the
+          # store stops returning null for days without data:
+          # https://github.com/canonical/snapcraft/blob/main/snapcraft/models/metrics.py
+          sudo snap install snapcraft --classic --channel=8.x/stable
 
       - name: Install jq
         run: |


### PR DESCRIPTION
snapcraft 9.0.0 rewrote the metrics command with pydantic models that reject the null data points the store returns for days without data, crashing with 1860 MetricsResponse validation errors. Pin to 8.x/stable until snapcraft accepts null values or the store stops sending them.