### PR TITLE
Drop vectors schema

### DIFF
--- a/docs/site/content/installation/revision-history.md
+++ b/docs/site/content/installation/revision-history.md
@@ -8,13 +8,20 @@ This page lists the revision history of Immich Distribution releases. Each revis
 
 {% admonition(type="info", title="Last updated") %}
 This page is updated from time to time with the latest revision information.
-Last updated: **2025-10-22**.
+Last updated: **2026-07-05**.
 {% end %}
 
 ## Revision Table
 
 | Era | Revision | Immich Version | Released | Comments |
 |-----|----------|----------------|----------|----------|
+| 2 | 267 | [v2.7.5](https://github.com/nsg/immich-distribution/issues/375) | 22 Apr 2026 | |
+| 2 | 266 | [v2.7.4](https://github.com/nsg/immich-distribution/issues/375) | 22 Apr 2026 | |
+| 2 | 264 | [v2.6.3](https://github.com/nsg/immich-distribution/issues/368) | 29 Mar 2026 | |
+| 2 | 258 | [v2.5.6](https://github.com/nsg/immich-distribution/issues/363) | 21 Feb 2026 | First era 2 release: pgvecto.rs removed from the image after the [VectorChord migration](/news/2025/08/31/vectorchord-migration-rollout/) |
+| 1 | 254 | [v2.4.1](https://github.com/nsg/immich-distribution/issues/360) | 27 Dec 2025 | |
+| 1 | 252 | [v2.3.1](https://github.com/nsg/immich-distribution/issues/356) | 12 Dec 2025 | |
+| 1 | 250 | [v2.2.3](https://github.com/nsg/immich-distribution/issues/352) | 08 Dec 2025 | |
 | 1 | 249 | [v2.1.0](https://github.com/nsg/immich-distribution/issues/349) | 17 Oct 2025 | |
 | 1 | 248 | [v2.0.1](https://github.com/nsg/immich-distribution/issues/344) | 10 Oct 2025 | |
 | 1 | 246 | [v1.144.1](https://github.com/nsg/immich-distribution/issues/342) | 09 Oct 2025 | |

--- a/docs/site/content/installation/upgrade-from-old-releases.md
+++ b/docs/site/content/installation/upgrade-from-old-releases.md
@@ -14,7 +14,7 @@ Systems that are regularly updated should move between supported eras sequential
 
 | Era | Version  | Revision | Notes                 |
 | --- | ---------| ---------| --------------------- |
-| 2   | v2.5.0   | -        | pgvecto.rs removed from image, [VectorChord migration](/news/2025/08/31/vectorchord-migration-rollout/) completed |
+| 2   | v2.5.6   | 258      | pgvecto.rs removed from image, [VectorChord migration](/news/2025/08/31/vectorchord-migration-rollout/) completed |
 | 1   | v1.142.1 | 240      | Eras implemented, [VectorChord migration](/news/2025/08/31/vectorchord-migration-rollout/) in progress |
 | 0   | -        | -        | A release before revision 240 is counted as era `0` |
 

--- a/docs/site/content/news/2026/07/05-vectorchord-migration-finalized.md
+++ b/docs/site/content/news/2026/07/05-vectorchord-migration-finalized.md
@@ -1,0 +1,13 @@
++++
+template = "blog-post.html"
+title = "VectorChord Migration Finalized"
+date = "2026-07-05"
+path = "news/2026/07/05/vectorchord-migration-finalized"
+authors = ["nsg"]
++++
+
+The [VectorChord migration](/news/2025/08/31/vectorchord-migration-rollout/) that rolled out last year is now complete. The next release performs the final cleanup step: dropping the empty `vectors` schema that pgvecto.rs left behind ([#327](https://github.com/nsg/immich-distribution/issues/327)).
+
+The pgvecto.rs extension itself is already gone. Immich dropped it from the database automatically after the migration, and the package stopped shipping it with era 2 (v2.5.6). The only trace left on systems that lived through the migration is an empty `vectors` schema in the database.
+
+Starting with the next release, this schema is removed automatically when the database service starts. The cleanup is safe: it only removes the schema if it exists, and it refuses to touch a schema that unexpectedly contains data. Fresh installs never had the schema and are unaffected. No action is needed on your part.

--- a/docs/site/content/news/2026/07/_index.md
+++ b/docs/site/content/news/2026/07/_index.md
@@ -1,0 +1,5 @@
++++
+sort_by = "date"
+transparent = true
+template = "blog-month.html"
++++

--- a/src/bin/postgres
+++ b/src/bin/postgres
@@ -25,6 +25,10 @@ drop_privileges $SNAP/bin/postgres-configure
     done
     
     drop_privileges $SNAP/usr/local/pgsql/bin/createdb --username=postgres immich
+
+    # Empty schema left behind by the pgvecto.rs to VectorChord migration (#327)
+    drop_privileges $SNAP/usr/local/pgsql/bin/psql --username=postgres -d immich \
+        -c "DROP SCHEMA IF EXISTS vectors;"
 ) &
 
 drop_privileges $SNAP/usr/local/pgsql/bin/postgres


### PR DESCRIPTION
This cleans up after the VectorChord migration I did last year.