### PR TITLE
deps: bump node snap from 20/stable to 22/stable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -45,7 +45,7 @@ The plugins build (`snap/snapcraft.yaml`) uses `sed` to downgrade `extism-js` fr
 Machine learning is built with `cpu` extras only (no CUDA/GPU). `libmimalloc.so.2` is preloaded via `LD_PRELOAD` - version in path must match the `nsg-mimalloc` package.
 
 ### Pinned External Dependencies
-Several deps are pinned with checksums and break if removed/republished: `jellyfin-ffmpeg7` deb (tied to `jammy`), `uv` (Python installer, version + SHA256), test assets (pinned git commit). Node.js comes from `node/20/stable` snap channel (EOL April 2026).
+Several deps are pinned with checksums and break if removed/republished: `jellyfin-ffmpeg7` deb (tied to `jammy`), `uv` (Python installer, version + SHA256), test assets (pinned git commit). Node.js comes from `node/22/stable` snap channel (LTS until April 2027). The `node/24` snap is built on `core24` (needs glibc 2.38+) and cannot run on our `core22` base.
 
 ### Era-Based Upgrade Protection
 `snap/hooks/post-refresh` blocks skipping eras (currently era `2` in `src/bin/load-env`). Users cannot skip intermediate era versions. Escape hatches: touching `$SNAP_COMMON/no-pre-refresh-hook` or `$SNAP_COMMON/no-post-refresh-hook` disables hooks entirely.

--- a/.claude/commands/verify-release.md
+++ b/.claude/commands/verify-release.md
@@ -101,7 +101,7 @@ The coordinator subagent must:
      - Changes to `extism-js` or plugin system
      - PostgreSQL, Redis, or other infrastructure changes
      - Python version requirement changes (we're pinned to 3.10 via core22)
-     - Node.js version requirement changes (we use node/20/stable snap)
+     - Node.js version requirement changes (we use node/22/stable snap)
    - Return: for each commit with relevant findings, the hash, one-line summary, and what specifically is relevant
 5. After all workers complete, **collate findings, discard commits with no findings**, and return a concise aggregated summary grouped by category
 

--- a/CORE24.md
+++ b/CORE24.md
@@ -95,7 +95,7 @@ Neither is currently used in this project, so no change needed.
 | Redis (system) | 6.0 | **7.0** |
 | Node.js (system) | 12.x | **18.x** |
 
-Note: This snap uses `nsg-*` packages and `node/20/stable` snap channel, not system packages directly.
+Note: This snap uses `nsg-*` packages and `node/22/stable` snap channel, not system packages directly. The `node/24` snap is built on `core24` and requires glibc 2.38+, so moving to it depends on this migration.
 
 ## Recommendation
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -241,9 +241,9 @@ parts:
       - libimagequant-dev
       - liblcms2-dev
     build-snaps:
-      - node/20/stable
+      - node/22/stable
     stage-snaps:
-      - node/20/stable
+      - node/22/stable
     stage-packages:
       - nsg-redis
       - nsg-libvips
@@ -287,7 +287,7 @@ parts:
     after:
       - parts-server-patches
     build-snaps:
-      - node/20/stable
+      - node/22/stable
 
   plugins:
     plugin: nil
@@ -326,7 +326,7 @@ parts:
       cp -r dist ${CRAFT_PART_INSTALL}/var/lib/immich/build/corePlugin/
       cp manifest.json ${CRAFT_PART_INSTALL}/var/lib/immich/build/corePlugin/
     build-snaps:
-      - node/20/stable
+      - node/22/stable
 
   uv-python312:
     plugin: nil


### PR DESCRIPTION
Node 20 reached EOL in April 2026. Node 22 is LTS until April 2027 and its snap is built on core22, requiring at most GLIBC_2.34 and GLIBCXX_3.4.30 - both available on our jammy base.

Node 24 (upstream's pin) is not an option yet: the node/24 snap is built on core24 and needs GLIBC_2.38+, which fails on core22 both at build and runtime (verified in CI on the abandoned deps/node-24 branch). Moving to node 24 depends on the core24 migration, noted in CORE24.md.

Closes #378