### PR TITLE
fix: quote "$@" in drop_privileges and psql wrapper

### DIFF
--- a/src/bin/load-env
+++ b/src/bin/load-env
@@ -101,7 +101,7 @@ drop_privileges() {
         --clear-groups \
         --reuid snap_daemon \
         --regid snap_daemon \
-        -- $@
+        -- "$@"
 }
 
 immich_server_ready() {

--- a/src/bin/psql
+++ b/src/bin/psql
@@ -9,4 +9,4 @@ if ! echo "$@" | grep -qE '(^| )(-U |--username[ =])'; then
     set -- -U postgres "$@"
 fi
 
-drop_privileges $SNAP/usr/local/pgsql/bin/psql $@
+drop_privileges $SNAP/usr/local/pgsql/bin/psql "$@"


### PR DESCRIPTION
Unquoted $@ word-splits arguments, so the vectors schema cleanup added in #395 ran `DROP` alone instead of the full quoted SQL statement and failed with a syntax error. The vectors schema is still present on production systems.

Quoting "$@" preserves argument boundaries. No existing caller relies on word splitting.