### PR TITLE
fix: keep plugin wasm paths valid across snap refreshes

### DIFF
--- a/src/bin/load-env
+++ b/src/bin/load-env
@@ -36,7 +36,11 @@ export IMMICH_PORT=3001
 export IMMICH_SERVER_URL="http://127.0.0.1:3001" # Not used by Immich anymore, but still used by Immich Distribution
 export IMMICH_HOST="127.0.0.1"
 export IMMICH_MACHINE_LEARNING_URL="http://127.0.0.1:3003"
-export IMMICH_BUILD_DATA="$SNAP/var/lib/immich/build" # Contains www, geodata and build-lock.json
+# Contains www, geodata and build-lock.json. Use the "current" symlink instead
+# of the revisioned $SNAP path: Immich stores paths derived from this (like the
+# core plugin wasmPath) in the database, and a revisioned path goes stale on
+# every snap refresh.
+export IMMICH_BUILD_DATA="${SNAP%/*}/current/var/lib/immich/build"
 export IMMICH_MEDIA_LOCATION="$SNAP_COMMON/upload"
 export IMMICH_API_METRICS_PORT=8081
 export IMMICH_MICROSERVICES_METRICS_PORT=8082

--- a/src/bin/postgres
+++ b/src/bin/postgres
@@ -29,6 +29,20 @@ drop_privileges $SNAP/bin/postgres-configure
     # Empty schema left behind by the pgvecto.rs to VectorChord migration (#327)
     drop_privileges $SNAP/usr/local/pgsql/bin/psql --username=postgres -d immich \
         -c "DROP SCHEMA IF EXISTS vectors;"
+
+    # Plugin wasm paths were stored with a revisioned $SNAP path and go stale
+    # on refresh, breaking plugin loading. Re-point them at the current symlink.
+    drop_privileges $SNAP/usr/local/pgsql/bin/psql --username=postgres -d immich <<EOF
+DO \$\$
+BEGIN
+    IF to_regclass('public.plugin') IS NOT NULL THEN
+        UPDATE plugin
+        SET "wasmPath" = regexp_replace("wasmPath", '^${SNAP%/*}/[x0-9]+/', '${SNAP%/*}/current/')
+        WHERE "wasmPath" ~ '^${SNAP%/*}/[x0-9]+/';
+    END IF;
+END
+\$\$;
+EOF
 ) &
 
 drop_privileges $SNAP/usr/local/pgsql/bin/postgres


### PR DESCRIPTION
Immich persists the core plugin wasmPath in the database at registration and never updates it while the plugin version matches. With IMMICH_BUILD_DATA based on the revisioned $SNAP path, the stored path breaks on the next refresh and the plugin fails to load (ENOENT on the old revision path).

- Point IMMICH_BUILD_DATA at the stable /snap/<name>/current symlink so newly stored paths survive refreshes
- Rewrite stale revisioned wasmPath rows to the current symlink at postgres startup, healing existing installs (production has been carrying a revision 258 path since February)