### PR TITLE
Update Jellyfin FFmpeg for CVE-2026-8461

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -426,9 +426,9 @@ parts:
     source: parts/manager
 
   jellyfin-ffmpeg:
-    source: https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v7.0.2-7/jellyfin-ffmpeg7_7.0.2-7-jammy_amd64.deb
+    source: https://github.com/jellyfin/jellyfin-ffmpeg/releases/download/v7.1.4-3/jellyfin-ffmpeg7_7.1.4-3-jammy_amd64.deb
     plugin: dump
-    source-checksum: sha256/f116e06281e5dc96a4b1d59a57aa39c1601deb01e9ed023d1741574886cc9432
+    source-checksum: sha256/4fccc21952a0badcb50261c3120eaaa57d726cee97339c6426bb5bcfc4dec3a5
     organize:
       usr/lib/jellyfin-ffmpeg/lib: usr/lib
       usr/lib/jellyfin-ffmpeg/share: usr/share


### PR DESCRIPTION
## Summary

- updates the bundled Jellyfin FFmpeg package from `v7.0.2-7` to `v7.1.4-3`
- updates the `source-checksum` for the new Jammy amd64 `.deb`
- pulls in Jellyfin FFmpeg's MagicYUV backport for FFmpeg CVE-2026-8461 / PixelSmash

## Context

CVE-2026-8461 is a heap out-of-bounds write in FFmpeg's MagicYUV decoder. FFmpeg fixed it in 8.1.2, and Jellyfin FFmpeg backported the fix to its 7.1 branch. The currently bundled `v7.0.2-7` package predates that backport.

Upstream Jellyfin issue: https://github.com/jellyfin/jellyfin-ffmpeg/issues/730
Backport patch in `v7.1.4-3`: https://github.com/jellyfin/jellyfin-ffmpeg/blob/v7.1.4-3/debian/patches/0094-backport-a-fix-from-upstream-for-magicyuv-decoder.patch

## Verification

- Verified the new GitHub release asset checksum:
  `4fccc21952a0badcb50261c3120eaaa57d726cee97339c6426bb5bcfc4dec3a5`
- Verified the downloaded package metadata with `dpkg-deb -f`:
  - `Package: jellyfin-ffmpeg7`
  - `Version: 7.1.4-3-jammy`
  - `Architecture: amd64`
- Verified no existing open PR matched `CVE-2026-8461` / `jellyfin-ffmpeg` before creating this PR.
